### PR TITLE
feat: add role-based access control to Account and MemberRepository c…

### DIFF
--- a/src/main/java/com/example/db/entity/Account.java
+++ b/src/main/java/com/example/db/entity/Account.java
@@ -1,6 +1,7 @@
 package com.example.db.entity;
 
 
+import com.example.db.enums.UserRole;
 import lombok.Data;
 
 @Data
@@ -11,13 +12,15 @@ public class Account {
 
     private String username;
     private String email;
+    private UserRole role = UserRole.USER;
 
     public Account(){};
 
-    public Account(Long loginId, String username, String email){
+    public Account(Long loginId, String username, String email, UserRole role) {
         this.loginId = loginId;
         this.username = username;
         this.email = email;
+        this.role = role;
     }
 
 

--- a/src/main/java/com/example/db/enums/UserRole.java
+++ b/src/main/java/com/example/db/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.db.enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/example/db/jdbc/MemberRepository.java
+++ b/src/main/java/com/example/db/jdbc/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.db.jdbc;
 
 import com.example.db.entity.Account;
+import com.example.db.enums.UserRole;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -22,7 +23,7 @@ public class MemberRepository {
     }
 
     public Account save(Account account){
-        String sql = "insert into account (login_id, username, email) values (?, ?, ?)";
+        String sql = "insert into account (login_id, username, email, role) values (?, ?, ?, ?)";
 
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
@@ -31,6 +32,7 @@ public class MemberRepository {
             ps.setLong(1, account.getLoginId());
             ps.setString(2, account.getUsername());
             ps.setString(3, account.getEmail());
+            ps.setString(4, account.getRole() != null ? account.getRole().name() : UserRole.USER.name());
             return ps;
         }, keyHolder);
 
@@ -39,8 +41,10 @@ public class MemberRepository {
         return account;
     }
 
+
+
     public Optional<Account> findByKakaoId(Long loginId){
-        String sql = "select id, login_id, username, email from account where login_id = ?";
+        String sql = "select id, login_id, username, email, role from account where login_id = ?";
         try {
             Account account = template.queryForObject(sql, accountRowMapper(), loginId);
             return Optional.of(account);
@@ -50,13 +54,18 @@ public class MemberRepository {
     }
 
     public Optional<Account> findByUsername(String username){
-        String sql = "select id, login_id, username, email from account where username = ?";
+        String sql = "select id, login_id, username, email, role from account where username = ?";
         try {
             Account account = template.queryForObject(sql, accountRowMapper(), username);
             return Optional.of(account);
         } catch (EmptyResultDataAccessException e){
             return Optional.empty();
         }
+    }
+
+    public void updateRole(Long loginId, UserRole role){
+        String sql = "update account set role = ? where login_id = ?";
+        template.update(sql, role.name(), loginId);
     }
 
     private RowMapper<Account> accountRowMapper(){
@@ -66,6 +75,7 @@ public class MemberRepository {
             account.setLoginId(rs.getLong("login_id"));
             account.setUsername(rs.getString("username"));
             account.setEmail(rs.getString("email"));
+            account.setRole(UserRole.valueOf(rs.getString("role")));
             return account;
         };
     }

--- a/src/main/java/com/example/db/service/KakaoAuthService.java
+++ b/src/main/java/com/example/db/service/KakaoAuthService.java
@@ -6,6 +6,7 @@ import com.example.db.dto.LoginResponseDTO;
 import com.example.db.entity.Account;
 import com.example.db.entity.JwtResponse;
 import com.example.db.entity.RefreshToken;
+import com.example.db.enums.UserRole;
 import com.example.db.jdbc.MemberRepository;
 import com.example.db.jdbc.RefreshTokenRepository;
 import com.example.db.jwt.JwtUtil;
@@ -23,6 +24,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -34,6 +36,8 @@ public class KakaoAuthService {
     private String REDIRECT_URI;
     @Value("${kakao.token-uri}")
     private String KAKAO_TOKEN_URI;
+    @Value("#{'${admin.emails}'.split(',')}")
+    private List<String> adminEmails;
 
     @Autowired
     private JwtUtil jwtUtil;
@@ -126,6 +130,9 @@ public class KakaoAuthService {
     }
 
      */
+
+
+    /*
     public ResponseEntity<LoginResponseDTO> kakaoLogin(String kakaoAccessToken) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -160,19 +167,19 @@ public class KakaoAuthService {
             String refreshJwt = jwtUtil.generateRefreshToken(account.getLoginId());
 
             // 기존에 존재하는 refreshToken이 있으면 업데이트, 없으면 새로 저장
-            /*
-            RefreshToken existingToken = refreshTokenRepository.findByUserId(account.getLoginId());
-            if (existingToken != null) {
-                // 기존 토큰이 있으면 업데이트
-                existingToken.setToken(refreshJwt);
-                existingToken.setExpiryDate(new Date(System.currentTimeMillis() + jwtUtil.getRefreshExpirationInMs()));
-                refreshTokenRepository.update(existingToken);
-            } else {
-                // 기존 토큰이 없으면 새로 저장
-                saveRefreshToken(account.getLoginId(), refreshJwt);
-            }
 
-             */
+            //RefreshToken existingToken = refreshTokenRepository.findByUserId(account.getLoginId());
+            //if (existingToken != null) {
+                // 기존 토큰이 있으면 업데이트
+            //    existingToken.setToken(refreshJwt);
+            //    existingToken.setExpiryDate(new Date(System.currentTimeMillis() + jwtUtil.getRefreshExpirationInMs()));
+            //    refreshTokenRepository.update(existingToken);
+            //} else {
+                // 기존 토큰이 없으면 새로 저장
+            //    saveRefreshToken(account.getLoginId(), refreshJwt);
+            //}
+
+
             Optional<RefreshToken> existingTokenOptional = refreshTokenRepository.findByUserId(account.getLoginId());
 
             if (existingTokenOptional.isPresent()) {
@@ -200,6 +207,83 @@ public class KakaoAuthService {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(loginResponseDto);
         }
     }
+    */
+    public ResponseEntity<LoginResponseDTO> kakaoLogin(String kakaoAccessToken) {
+
+        HttpHeaders headers = new HttpHeaders();
+        LoginResponseDTO loginResponseDto = new LoginResponseDTO();
+        Account account;
+
+        try {
+            // 카카오 사용자 정보 가져오기
+            account = getKakaoInfo(kakaoAccessToken);
+            if (account == null) {
+                throw new IllegalArgumentException("Failed to fetch account information from Kakao");
+            }
+
+            if(adminEmails.contains(account.getEmail())){
+                account.setRole(UserRole.ADMIN);
+                System.out.println("바껴야 하는 account = " + account.getEmail());
+            }else {
+                account.setRole(UserRole.USER);
+            }
+
+        } catch (Exception e) {
+            loginResponseDto.setLoginSuccess(false);
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(loginResponseDto);
+        }
+
+        try {
+            // 이미 존재하는 사용자 확인
+            Account existOwner = memberRepository.findByKakaoId(account.getLoginId()).orElse(null);
+            if (existOwner == null) {
+                // 사용자 없으면 새로 저장
+                memberRepository.save(account);
+            } else {
+                // 사용자 있으면 기존 사용자 정보 사용
+                if(!existOwner.getRole().equals(account.getRole())){
+                    existOwner.setRole(account.getRole());
+                    memberRepository.updateRole(existOwner.getLoginId(), account.getRole());
+                }
+                account = existOwner;
+            }
+
+            // 토큰 생성
+            String jwt = jwtUtil.generateToken(account.getLoginId(), account.getEmail(), account.getUsername());
+            String refreshJwt = jwtUtil.generateRefreshToken(account.getLoginId());
+
+            // 기존에 존재하는 refreshToken이 있으면 업데이트, 없으면 새로 저장
+            RefreshToken existingToken = refreshTokenRepository.findByUserId(account.getLoginId()).orElse(null);
+
+            if (existingToken != null) {
+                // 기존 토큰이 있으면 업데이트
+                existingToken.setToken(refreshJwt);
+                existingToken.setExpiryDate(new Date(System.currentTimeMillis() + jwtUtil.getRefreshExpirationInMs()));
+                refreshTokenRepository.save(existingToken);  // save 메서드로 업데이트합니다.
+            } else {
+                // 기존 토큰이 없으면 새로 저장
+                saveRefreshToken(account.getLoginId(), refreshJwt);
+            }
+
+            headers.add("Authorization", "Bearer " + jwt);
+
+            loginResponseDto.setLoginSuccess(true);
+            loginResponseDto.setAccount(account);
+            loginResponseDto.setJwtToken(jwt);
+            loginResponseDto.setRefreshToken(refreshJwt);
+
+            // 응답에 Authorization 헤더를 포함
+            return ResponseEntity.ok().headers(headers).body(loginResponseDto);
+        } catch (Exception e) {
+            loginResponseDto.setLoginSuccess(false);
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(loginResponseDto);
+        }
+    }
+
+
+
 
 
 
@@ -264,7 +348,8 @@ public class KakaoAuthService {
             return new Account(
                     kakaoAccountDto.getId(),
                     kakaoAccountDto.getProperties().getNickname(),
-                    kakaoAccountDto.getKakao_account().getEmail()
+                    kakaoAccountDto.getKakao_account().getEmail(),
+                    UserRole.USER
             );
         }
 


### PR DESCRIPTION
…lasses

- Added `UserRole` enum to distinguish between `USER` and `ADMIN` roles.
- Modified `Account` entity to include `UserRole` field, defaulting to `USER`.
- Updated `MemberRepository` to handle `role` field:
  - `save` method now includes `role` in database insert operations.
  - Added `updateRole` method to update role in database for existing accounts.
  - Updated row mapper to map `UserRole` for Account objects.
- Enhanced `KakaoAuthService` to assign role based on email list for admin privileges.
- Adjusted Kakao login flow to ensure role consistency with database, updating if necessary.